### PR TITLE
added different targets for mpi omp and hybrid

### DIFF
--- a/Obj/CMakeLists.txt
+++ b/Obj/CMakeLists.txt
@@ -38,30 +38,34 @@ target_link_libraries(ljmd_hybrid.x ljdm-lib m ${MPI_LIBRARIES})
 # Compile the serial optimized version of the code
 set_target_properties(ljmd.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
 # Compile the serial optimized version of the code
-add_custom_target(optimized DEPENDS ljmd.x)
+add_custom_target(optimized DEPENDS ljmd.x
+    COMMENT "Building optimized serial version.")
 
 # Add MPI flags
 set_target_properties(ljmd_mpi.x PROPERTIES COMPILE_FLAGS "-D_MPI=1" RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
 # Create the mpi target
-add_custom_target(mpi DEPENDS ljmd_mpi.x)
+add_custom_target(mpi DEPENDS ljmd_mpi.x
+    COMMENT "Building MPI version.")
 # Rename executable
 set_target_properties(ljmd_mpi.x PROPERTIES OUTPUT_NAME ljmd.x)
 
 # Add OpenMP flags
 set_target_properties(ljmd_omp.x PROPERTIES COMPILE_FLAGS "-fopenmp -D_OPENMP=1" LINK_FLAGS "-fopenmp" RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
 # Create the openmp target
-add_custom_target(omp DEPENDS ljmd_omp.x)
+add_custom_target(omp DEPENDS ljmd_omp.x
+    COMMENT "Building OpenMP version.")
 # Rename executable
 set_target_properties(ljmd_omp.x PROPERTIES OUTPUT_NAME ljmd.x)
 
 # Add MPI and OpenMP flags
 set_target_properties(ljmd_hybrid.x PROPERTIES COMPILE_FLAGS "-fopenmp -D_OPENMP=1 -D_MPI=1" LINK_FLAGS "-fopenmp" RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
 # Create the hybrid target
-add_custom_target(hybrid DEPENDS ljmd_hybrid.x)
+add_custom_target(hybrid DEPENDS ljmd_hybrid.x
+    COMMENT "Building hybrid version.")
 # Rename executable
 set_target_properties(ljmd_hybrid.x PROPERTIES OUTPUT_NAME ljmd.x)
 
 
 # Add the clean target
-add_custom_target(clean_parrallel COMMAND rm -f *.mod *.o ../ljmd.x)
+add_custom_target(clean_parallel COMMAND rm -f *.mod *.o ../ljmd.x)
 

--- a/Obj/CMakeLists.txt
+++ b/Obj/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # set compiler options
-set(CMAKE_C_FLAGS "-Wall -g -O3 -ffast-math -fomit-frame-pointer -DLJMD_VERSION=1.0 -D_OMP=1 -fopenmp -D_MPI=1")
+set(CMAKE_C_FLAGS "-Wall -g -O3 -ffast-math -fomit-frame-pointer -DLJMD_VERSION=1.0")
 
 # Add include directories
 include_directories(../include)
@@ -22,14 +22,45 @@ add_library(ljdm-lib
 )
 # Create the executable "ljmd.x"
 add_executable(ljmd.x ../src/main.c)
+# Create the mpi executable "ljmd_mpi.x"
+add_executable(ljmd_mpi.x ../src/main.c)
+# Create the openmp executable "ljmd_omp.x"
+add_executable(ljmd_omp.x ../src/main.c)
+# Create the hybrid executable "ljmd_hybrid.x"
+add_executable(ljmd_hybrid.x ../src/main.c)
 
 # Link the library to the math library
-target_link_libraries(ljmd.x ljdm-lib m ${MPI_LIBRARIES})
+target_link_libraries(ljmd.x ljdm-lib m)
+target_link_libraries(ljmd_mpi.x ljdm-lib m ${MPI_LIBRARIES})
+target_link_libraries(ljmd_omp.x ljdm-lib m)
+target_link_libraries(ljmd_hybrid.x ljdm-lib m ${MPI_LIBRARIES})
 
+# Compile the serial optimized version of the code
 set_target_properties(ljmd.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+# Compile the serial optimized version of the code
+add_custom_target(optimized DEPENDS ljmd.x)
 
-# Compile the serial version of the code
-add_custom_target(parallel DEPENDS ljmd.x)
+# Add MPI flags
+set_target_properties(ljmd_mpi.x PROPERTIES COMPILE_FLAGS "-D_MPI=1" RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+# Create the mpi target
+add_custom_target(mpi DEPENDS ljmd_mpi.x)
+# Rename executable
+set_target_properties(ljmd_mpi.x PROPERTIES OUTPUT_NAME ljmd.x)
+
+# Add OpenMP flags
+set_target_properties(ljmd_omp.x PROPERTIES COMPILE_FLAGS "-fopenmp -D_OPENMP=1" LINK_FLAGS "-fopenmp" RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+# Create the openmp target
+add_custom_target(omp DEPENDS ljmd_omp.x)
+# Rename executable
+set_target_properties(ljmd_omp.x PROPERTIES OUTPUT_NAME ljmd.x)
+
+# Add MPI and OpenMP flags
+set_target_properties(ljmd_hybrid.x PROPERTIES COMPILE_FLAGS "-fopenmp -D_OPENMP=1 -D_MPI=1" LINK_FLAGS "-fopenmp" RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+# Create the hybrid target
+add_custom_target(hybrid DEPENDS ljmd_hybrid.x)
+# Rename executable
+set_target_properties(ljmd_hybrid.x PROPERTIES OUTPUT_NAME ljmd.x)
+
 
 # Add the clean target
 add_custom_target(clean_parrallel COMMAND rm -f *.mod *.o ../ljmd.x)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,7 @@ target_link_libraries(GoogleTests ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
 enable_testing()
 
 GTEST_DISCOVER_TESTS(GoogleTests)
+
+# add unittest target
+add_custom_target(unittest DEPENDS GoogleTests
+    COMMENT "Running unit tests")


### PR DESCRIPTION
Added new targets to cmake. Now we have options to compile using mpi, omp, both or none as the following:

Build the cmake as usual:
```bash
mkdir build
cd build
cmake ..
```

Now we have the following make options :
**Remember to always do `make clean` when testing different targets!**
`make serial`: builds the original code
`make optimized`: builds the serial optimized code
`make mpi`: builds the optimized code with the MPI implementation, that is with `-D_MPI=1` flag
`make omp`: builds the optimized code with the openMP implementation, that is with `-D_OPEN=1 - fopenmp` flags
`make hybrid`: builds with both MPI and openMP flags


